### PR TITLE
Allow the latest version of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"xo": "^0.28.1"
 	},
 	"engines": {
-		"node": ">=10.0.0"
+		"node": ">=8.3.0"
 	},
 	"keywords": [
 		"netlify",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"xo": "^0.28.1"
 	},
 	"engines": {
-		"node": "12"
+		"node": ">=12.0.0"
 	},
 	"keywords": [
 		"netlify",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"xo": "^0.28.1"
 	},
 	"engines": {
-		"node": ">=12.0.0"
+		"node": ">=10.0.0"
 	},
 	"keywords": [
 		"netlify",


### PR DESCRIPTION
While Netlify [supports](https://github.com/netlify/build/blob/c5a009857bea82adaecf08002fd821be0e24453e/package.json#L47) all version down to v8, they plan to change this aspect: https://github.com/netlify/build/issues/939.

In my case, I believe I need this change to use the plugin.
- Without adding the dependency in my yarn workspace, we get:

> 2:45:33 AM: ❯ Installing plugins
2:45:33 AM:    - netlify-plugin-cache-nextjs
2:45:33 AM: ​
2:45:33 AM: ​
2:45:33 AM: ┌─────────────────────────────┐
2:45:33 AM: │     Dependencies error      │
2:45:33 AM: └─────────────────────────────┘
2:45:33 AM: ​
2:45:33 AM: ❯ Error message
2:45:33 AM:   Error while installing dependencies in /opt/build/repo
2:45:33 AM:   yarn add v1.21.1
2:45:33 AM:   error Running this command will add the dependency to the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).
2:45:33 AM:   info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
2:45:33 AM: ​
- But adding the dependency in my yarn workspace, we get:

> error netlify-plugin-cache-nextjs@1.3.0: The engine "node" is incompatible with this module. Expected version "12". Got "13.8.0"